### PR TITLE
Identity - IQueryable do not close connexions

### DIFF
--- a/Source Code 1-31/30 - Advanced Identity/Users/src/Users/Controllers/RoleAdminController.cs
+++ b/Source Code 1-31/30 - Advanced Identity/Users/src/Users/Controllers/RoleAdminController.cs
@@ -22,7 +22,7 @@ namespace Users.Controllers {
             userManager = userMrg;
         }
 
-        public ViewResult Index() => View(roleManager.Roles);
+        public ViewResult Index() => View(roleManager.Roles.ToList());
 
         public IActionResult Create() => View();
 

--- a/Source Code 1-31/30 - Advanced Identity/Users/src/Users/Infrastructure/RoleUsersTagHelper.cs
+++ b/Source Code 1-31/30 - Advanced Identity/Users/src/Users/Infrastructure/RoleUsersTagHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -27,7 +28,8 @@ namespace Users.Infrastructure {
             List<string> names = new List<string>();
             IdentityRole role = await roleManager.FindByIdAsync(Role);
             if (role != null) {
-                foreach (var user in userManager.Users) {
+                var listUser = userManager.Users.ToList();
+                foreach (var user in listUser) {
                     if (user != null
                         && await userManager.IsInRoleAsync(user, role.Name)) {
                         names.Add(user.UserName);


### PR DESCRIPTION
§ .net Core 1.1
§ Visual studio 2017 RC candidate
§ Sql Server 2014 express

I'm having some problem with identity userManager and identityManager.

"InvalidOperationException: There is already an open DataReader associated with this Command which must be closed first."

Using userManager.Users return a IQueryable<users>. As a consequence, it seems that it doesn't close the connection immediately when enumerating it, or something similar.

If inside the enumeration, we use a method of userManager, it will throw the error. 

The way around is to transform the IQueryAble to real data, and thus close the connection as soon as possible.

I don't know if this is the normal behavior or a bug of Identity/Core itself.